### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/Sources/NSTD.SrkToolkit.AspNetCore/NSTD.SrkToolkit.AspNetCore.csproj
+++ b/Sources/NSTD.SrkToolkit.AspNetCore/NSTD.SrkToolkit.AspNetCore.csproj
@@ -8,7 +8,15 @@
     <Company />
     <Authors />
     <PackageId>SrkToolkit.AspNetCore</PackageId>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />

--- a/Sources/NSTD.SrkToolkit.Common/NSTD.SrkToolkit.Common.csproj
+++ b/Sources/NSTD.SrkToolkit.Common/NSTD.SrkToolkit.Common.csproj
@@ -11,7 +11,15 @@
     <AssemblyName>SrkToolkit.Common</AssemblyName>
     <RootNamespace>SrkToolkit</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE;NSTD</DefineConstants>

--- a/Sources/NSTD.SrkToolkit.Domain/NSTD.SrkToolkit.Domain.csproj
+++ b/Sources/NSTD.SrkToolkit.Domain/NSTD.SrkToolkit.Domain.csproj
@@ -11,7 +11,15 @@
     <AssemblyName>SrkToolkit.Domain</AssemblyName>
     <RootNamespace>SrkToolkit</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;NSTD</DefineConstants>

--- a/Sources/NSTD.SrkToolkit.Web/NSTD.SrkToolkit.Web.csproj
+++ b/Sources/NSTD.SrkToolkit.Web/NSTD.SrkToolkit.Web.csproj
@@ -9,7 +9,15 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors />
     <Company />
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;NSTD</DefineConstants>


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
